### PR TITLE
Testing CodeRabbit review with intentional violations

### DIFF
--- a/defaults/test_violations.yml
+++ b/defaults/test_violations.yml
@@ -1,0 +1,10 @@
+---
+# VIOLATION: Variables in defaults/ not prefixed with mssql_
+database_port: 1433
+sql_version: "2022"
+
+# VIOLATION: Internal variable (double underscore) in defaults/
+__internal_flag: false
+
+# Correct variable for comparison
+mssql_correct_variable: true

--- a/handlers/test_violations.yml
+++ b/handlers/test_violations.yml
@@ -1,0 +1,8 @@
+---
+# VIOLATION: Handler with sensitive data not using secure_logging
+- name: Apply database configuration with password
+  ansible.builtin.command: >
+    /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P {{ mssql_password }}
+    -Q "RECONFIGURE"
+  no_log: true
+  changed_when: true

--- a/tasks/test_violations.yml
+++ b/tasks/test_violations.yml
@@ -1,0 +1,42 @@
+---
+# This file intentionally violates CodeRabbit rules for testing
+
+# VIOLATION 1: Using hardcoded no_log: true instead of parametrized
+- name: Get database password
+  ansible.builtin.command: cat /etc/mssql/password
+  register: db_password
+  no_log: true
+  changed_when: false
+
+# VIOLATION 2: Using yum instead of package module
+- name: Install SQL Server packages
+  ansible.builtin.yum:
+    name: mssql-server
+    state: present
+
+# VIOLATION 3: Using package but missing OSTree use: parameter
+- name: Install additional tools
+  ansible.builtin.package:
+    name: mssql-tools
+    state: present
+
+# VIOLATION 4: Using third-party collection
+- name: Create archive of logs
+  community.general.archive:
+    path: /var/log/mssql
+    dest: /tmp/mssql-logs.tar.gz
+
+# VIOLATION 5: Not using FQCN for system role
+- name: Configure firewall
+  include_role:
+    name: firewall
+  vars:
+    firewall_port: 1433
+
+# VIOLATION 6: package_facts without verbosity-based no_log
+- name: Gather package information
+  package_facts:
+
+# VIOLATION 7: command without changed_when
+- name: Check SQL Server status
+  ansible.builtin.command: systemctl status mssql-server

--- a/templates/test_violation.conf.j2
+++ b/templates/test_violation.conf.j2
@@ -1,0 +1,4 @@
+# VIOLATION: Missing ansible_managed header and role fingerprint
+[mssql]
+port = {{ mssql_tcp_port | d(1433) }}
+password = {{ mssql_password }}

--- a/tests/tests_violations.yml
+++ b/tests/tests_violations.yml
@@ -1,0 +1,11 @@
+---
+# VIOLATION: Test file using include_role directly instead of wrapper
+- name: Test MSSQL role violations
+  hosts: all
+  tasks:
+    - name: Run mssql role incorrectly
+      ansible.builtin.include_role:
+        name: mssql
+      vars:
+        mssql_password: "TestPassword123"
+        mssql_version: "2022"

--- a/vars/test_violations.yml
+++ b/vars/test_violations.yml
@@ -1,0 +1,11 @@
+---
+# VIOLATION: Internal variables in vars/ not prefixed with __mssql_
+internal_packages:
+  - mssql-server
+  - mssql-tools
+
+# VIOLATION: User-facing variable in vars/ (should be in defaults/)
+mssql_user_option: "value"
+
+# Correct internal variable for comparison
+__mssql_correct_internal: true


### PR DESCRIPTION
## Purpose
This PR intentionally includes code violations to test CodeRabbit's review capabilities.

## Violations Included

### tasks/test_violations.yml:
- ❌ Hardcoded `no_log: true` instead of `no_log: "{{ mssql_secure_logging }}"`
- ❌ Using `yum` module instead of `package`
- ❌ Using `package` module without OSTree `use:` parameter
- ❌ Using third-party collection `community.general.archive`
- ❌ Not using FQCN for system role (just `firewall` instead of `fedora.linux_system_roles.firewall`)
- ❌ `package_facts` without verbosity-based `no_log`
- ❌ `command` module without `changed_when`

### tests/tests_violations.yml:
- ❌ Using `include_role` directly instead of `tasks/run_role_with_clear_facts.yml` wrapper

### templates/test_violation.conf.j2:
- ❌ Missing `ansible_managed` header
- ❌ Missing role fingerprint

### defaults/test_violations.yml:
- ❌ Variables not prefixed with `mssql_`
- ❌ Internal variable (`__internal_flag`) in defaults/ instead of vars/

### vars/test_violations.yml:
- ❌ Internal variables not prefixed with `__mssql_`
- ❌ User-facing variable in vars/ instead of defaults/

### handlers/test_violations.yml:
- ❌ Using hardcoded `no_log: true` instead of `no_log: "{{ mssql_secure_logging }}"`

### PR Title:
- ❌ Not following Conventional Commits format (should be `test:` or `chore:`)

## Expected CodeRabbit Behavior

CodeRabbit should flag all of these violations based on the rules in `.coderabbit.yaml`.

**Note:** This PR should NOT be merged. It's for testing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures for violation detection and validation across multiple components
  * Includes tests for configuration handling, task execution, template rendering, variable validation, and handler operations
  * Enhanced playbook testing for comprehensive role integration verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spetrosi/mssql/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->