### PR TITLE
feat: add CodeRabbit configuration for automated PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,65 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 # CodeRabbit configuration for linux-system-roles
 # Based on conventions from https://linux-system-roles.github.io/contribute.html
 # Replace <rolename> with actual role name when copying to other roles
 
+chat:
+  art: false
+
 reviews:
+  # Disable fun features
+  poem: false
+  in_progress_fortune: false
+
+  # Disable auto-features
+  auto_apply_labels: false
+  auto_assign_reviewers: false
+  request_changes_workflow: false
+
+  # Disable additional review features
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  suggested_labels: false
+  high_level_summary_in_walkthrough: false
+
+  # Disable finishing touches
+  finishing_touches:
+    unit_tests:
+      enabled: false
+
+  # Enforce PR title and description requirements
+  pre_merge_checks:
+    title:
+      mode: "warning"
+      requirements: |
+        PR title MUST follow Conventional Commits format:
+        - Format: <type>: <description> or <type>!: <description> for breaking changes
+        - Valid types: feat, fix, docs, test, tests, refactor, ci, chore, build, perf, style, revert
+        - Examples:
+          - "feat: Add backup functionality"
+          - "fix: Correct OSTree package installation"
+          - "fix!: Remove deprecated variable (breaking change)"
+
+    description:
+      mode: "warning"
+      requirements: |
+        PR description MUST follow the template structure from .github/pull_request_template.md:
+        - Must contain "Enhancement:" or "Feature:" section describing what changed
+        - Must contain "Reason:" section explaining why the change was needed
+        - Must contain "Result:" section describing the outcome or impact
+        - Must contain "Issue Tracker Tickets (Jira or BZ if any):" section (can be empty/none)
+
+        Example:
+        ```
+        Feature: Introduce the <rolename>_secure_logging variable
+
+        Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult.
+
+        Result: Users can now set <rolename>_secure_logging: false for debugging while maintaining secure defaults.
+
+        Issue Tracker Tickets (Jira or BZ if any): RHEL-12345
+        ```
+
   path_instructions:
     # ========================================
     # Ansible Tasks - Core role logic
@@ -10,8 +67,22 @@ reviews:
     - path: "tasks/**/*.yml"
       instructions: |
         **no_log patterns:**
-        - For sensitive data (credentials, secrets, passwords, keys): use `no_log: "{{ <rolename>_secure_logging }}"` and set <rolename>_secure_logging to true in defaults/main.yml
-        - For facts modules (package_facts, service_facts): use `no_log: "{{ ansible_verbosity < 2 }}"`
+        - For sensitive data (credentials, secrets, passwords, keys):
+          ```yaml
+          - name: Task with sensitive data
+            ansible.builtin.command: sensitive command
+            no_log: "{{ <rolename>_secure_logging }}"
+          ```
+          Ensure `<rolename>_secure_logging: true` is defined in defaults/main.yml
+
+        - For facts modules (package_facts, service_facts):
+          ```yaml
+          - name: Gather package facts
+            ansible.builtin.package_facts:
+            no_log: "{{ ansible_verbosity < 3 }}"
+          ```
+          This hides verbose facts output unless running with -vvv or higher verbosity
+
         - NEVER use hardcoded `no_log: true` - always parametrize
 
         **Package installation (OSTree compatibility):**
@@ -39,14 +110,10 @@ reviews:
 
         **Pattern explanation:**
         - `__<rolename>_is_ostree` detects OSTree/rpm-ostree systems (RHEL/CentOS/Fedora variants)
+        - This variable should already exist in vars/main.yml - do NOT suggest adding it
         - `| d(false)` provides safe default if variable undefined
         - `ternary()` selects `ansible.posix.rhel_rpm_ostree` for OSTree, `omit` otherwise
         - `omit` removes the parameter entirely on non-OSTree Red Hat systems
-
-        **OSTree detection (in vars/main.yml):**
-        ```yaml
-        __<rolename>_is_ostree: "{{ ansible_facts['ostree-booted'] is defined }}"
-        ```
 
         **Third-party collections:**
         - Avoid using third-party collections (community.general, community.crypto, etc.)
@@ -119,12 +186,3 @@ reviews:
       instructions: |
         - Document all new user-facing variables
         - Include usage examples for new functionality
-
-    # ========================================
-    # PR Conventions (all files)
-    # ========================================
-    - path: "*"
-      instructions: |
-        **PR titles (Conventional Commits):**
-        - Format: `<type>: <description>` or `<type>!: <description>` (breaking change)
-        - Types: feat, fix, docs, test, refactor, ci, chore


### PR DESCRIPTION
## Summary
This PR adds a comprehensive CodeRabbit configuration file () that enforces linux-system-roles coding standards during automated PR reviews.

## Custom Review Rules

### Ansible Tasks
- **no_log parametrization**: Enforces  for sensitive data and  for facts modules
- **OSTree compatibility**: Requires  parameter for package module on Red Hat family systems
- **Third-party collections**: Flags usage of community.general and similar collections
- **FQCN requirements**: Enforces fully qualified collection names for system roles

### Test Files
- **Role invocation**: Requires  wrapper instead of direct 

### Templates
- **Required headers**: ansible_managed header + role fingerprint

### Variable Definitions
- **Naming conventions**: 
  - Public variables:  prefix (in defaults/)
  - Internal variables:  prefix (in vars/)

### Code Quality
- **Python**: PEP 8 + Black formatting
- **PR titles**: Conventional Commits format

## Disabled Features

The configuration disables CodeRabbit's optional features to keep reviews focused:
- Poems, fortune messages, ASCII art
- Auto-apply labels and reviewers
- Sequence diagrams and effort estimation
- Unit test generation
- Suggested labels

## Reusability

The configuration uses `<rolename>` placeholders, making it reusable across all linux-system-roles repositories with simple find-and-replace.

## Testing

Tested on PR #16 which successfully caught multiple violations including:
- Hardcoded `no_log: true`
- Missing OSTree `use:` parameter
- Using `yum` instead of `package`
- Using third-party collections
- Incorrect test file patterns
- Missing template headers
- Variable naming violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled artwork/chat and several automated review behaviors (fun/auto/presentation/finishing), including unit-test finishing and walkthrough/label/sequencing helpers.
  * Added a warning-mode commit-title check enforcing allowed Conventional Commit types.

* **Documentation**
  * Clarified secure-logging guidance with parameterized no_log examples and required defaults variable.
  * Revised OSTree installation guidance to describe conditional use + ternary behavior.
  * Removed the global PR title/Conventional Commits guidance block.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spetrosi/mssql/pull/17)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->